### PR TITLE
修复奇怪的段错误

### DIFF
--- a/include/IR/SymbolUtil.h
+++ b/include/IR/SymbolUtil.h
@@ -79,7 +79,7 @@ namespace SysYust::IR {
 
         [[nodiscard]] label_type full() const;
         friend bool operator< (const var_symbol &lhs, const var_symbol &rhs) {
-            if (auto key1 = lhs.symbol < rhs.symbol; key1 != 0) {
+            if (auto key1 = lhs.symbol < rhs.symbol; lhs.symbol != rhs.symbol) {
                 return key1;
             } else {
                 return lhs.revision < rhs.revision;

--- a/src/backend/InstSel/InstSel.cpp
+++ b/src/backend/InstSel/InstSel.cpp
@@ -73,7 +73,7 @@ instruction InstSel::emitADDI(var_symbol op1, int op2) {
 var_symbol InstSel::ldfimm(operant op) {
     auto imm = op.im();
     auto val = imm | imf;
-    int equ_imm = std::bit_cast<int>(val);
+    int equ_imm = __builtin_bit_cast(int, val);
     auto imm1 = createInst<LW>(equ_imm);
     return createInst<FMV_X_W>(imm1);
 }


### PR DESCRIPTION
- 使得 var_symbol 的序严格（三鹿比较余孽.jpg)
- 更换 std::bit_cast 为 __builtin_bit_cast